### PR TITLE
Include mining income in total assets

### DIFF
--- a/tax.py
+++ b/tax.py
@@ -67,6 +67,11 @@ def compute_tax(trades, from_date, to_date, native_currency='SEK', exclude_group
                 tax_event = sell_coin.sell(trade.sell_amount, trade.sell_value)
                 if trade.date >= from_date:
                     tax_events.append(tax_event)
+        
+        elif trade.type == 'Mining':
+            buy_coin = get_buy_coin(trade)
+            if buy_coin:
+                buy_coin.buy(trade.buy_amount, trade.buy_value)
 
         elif trade.type == 'Gift/Tip':
             buy_coin = get_buy_coin(trade)


### PR DESCRIPTION
Allow CoinTracking mining income to be included in total assets.