### PR TITLE
Process trades on same minute in correct order

### DIFF
--- a/taxdata.py
+++ b/taxdata.py
@@ -124,6 +124,7 @@ class Trades:
             trades.append(trade)
             lineno += 1
 
+        trades.reverse()
         trades.sort(key=lambda x: x.date)
 
         return Trades(trades)


### PR DESCRIPTION
Thank you for providing this project! This saved me a lot of time. 

When running it I had problems with trades occuring on the same minute. Since
the input file from Cointracking only has minute resolution. 

The input file is specified from newest to oldest. Hence if we reverse the list
before sorting by date items on the same minute will be processed in correct order.