### PR TITLE
add dateutil depend, add /usr/bin/env shebang, bump Pillow version

### DIFF
--- a/report.py
+++ b/report.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import datetime
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pdfrw==0.4
-Pillow==5.0.0
+Pillow==6.0.0
 python-dateutil==2.7.2
 reportlab==3.4.0
 six==1.11.0
+python-dateutil==2.8.0


### PR DESCRIPTION
Had problem with homebrew and Pillow, my mac was trying to build it from source and failed (zlib fail, using pip -r requirements.txt), installed w/o specifying version did go through. Running with Pillow 6.0.0 in venv.